### PR TITLE
Raise specific error instead of FunctionClauseError

### DIFF
--- a/lib/ecto/adapters/mysql/connection.ex
+++ b/lib/ecto/adapters/mysql/connection.ex
@@ -127,7 +127,7 @@ if Code.ensure_loaded?(Mariaex) do
     end
 
     @impl true
-    def delete_all(%{select: nil} = query) do
+    def delete_all(query) do
       if query.select do
         error!(nil, ":select is not supported in delete_all by MySQL")
       end


### PR DESCRIPTION
Raise the specific error when delete_all/1 is called with a non nil select clause